### PR TITLE
ci: add Jekyll build workflow + Makefile

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -1,0 +1,48 @@
+name: Jekyll Site CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        cache: bundler
+
+    - name: Install system deps (Chromium for Puppeteer)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y chromium-browser ca-certificates fonts-liberation libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libgtk-3-0 libnspr4 libxss1
+
+    - name: Install dependencies
+      run: bundle install --jobs 4 --retry 3
+
+    - name: Build site
+      env:
+        PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium-browser
+        PUPPETEER_ARGS: '--no-sandbox --disable-setuid-sandbox'
+      run: bundle exec jekyll build --trace
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: site
+        path: _site
+
+    - name: Run HTML Proofer (optional)
+      if: success()
+      run: |
+        gem install html-proofer
+        htmlproofer _site --check-external-hash --allow-hash-href

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ install:
 build:
 	bundle exec jekyll build --trace
 
+# Use system Chromium for Puppeteer-based plugins (jekyll-diagrams)
+# Exports ensure Puppeteer uses the installed browser and disables sandboxing
+build-chrome:
+	export PUPPETEER_EXECUTABLE_PATH=$(shell which chromium-browser || which chromium || which google-chrome-stable) ; \
+	export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox' ; \
+	bundle exec jekyll build --trace
+
 serve:
 	bundle exec jekyll serve --drafts --livereload
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# Makefile for common Jekyll tasks
+
+install:
+	bundle install
+
+build:
+	bundle exec jekyll build --trace
+
+serve:
+	bundle exec jekyll serve --drafts --livereload
+
+clean:
+	rm -rf _site .jekyll-cache
+
+deploy-gh-pages:
+	# placeholder for future deployment steps
+	echo "Add deployment steps here"

--- a/README.md
+++ b/README.md
@@ -92,3 +92,24 @@ As I advance in technology and data science, I recognize that technical expertis
 ---
 
 *Let’s build a more equitable digital future together!*
+
+---
+
+## 🛠️ Build & CI notes
+
+If you use `jekyll-diagrams` (Mermaid) the plugin requires Puppeteer/Chromium to render diagrams during the build. Common issues and solutions:
+
+- "Failed to launch the browser process": install system Chromium (Ubuntu/Debian example):
+
+  sudo apt update && sudo apt install -y chromium-browser ca-certificates fonts-liberation libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libgtk-3-0 libnspr4 libxss1
+
+- You can set environment variables when building locally:
+
+  export PUPPETEER_EXECUTABLE_PATH=$(which chromium-browser)
+  export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox'
+  bundle exec jekyll build
+
+- CI: the repository includes a GitHub Actions workflow at `.github/workflows/jekyll-build.yml` which installs Chromium and sets `PUPPETEER_EXECUTABLE_PATH` before building.
+
+If you prefer not to install Chromium, temporarily disable `jekyll-diagrams` in `_config.yml` while editing content.
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ If you use `jekyll-diagrams` (Mermaid) the plugin requires Puppeteer/Chromium to
   export PUPPETEER_ARGS='--no-sandbox --disable-setuid-sandbox'
   bundle exec jekyll build
 
+  Or use the Makefile helper:
+
+  make build-chrome
+
+- CI: the repository includes a GitHub Actions workflow at `.github/workflows/jekyll-build.yml` which installs Chromium and sets `PUPPETEER_EXECUTABLE_PATH` before building.
+
 - CI: the repository includes a GitHub Actions workflow at `.github/workflows/jekyll-build.yml` which installs Chromium and sets `PUPPETEER_EXECUTABLE_PATH` before building.
 
 If you prefer not to install Chromium, temporarily disable `jekyll-diagrams` in `_config.yml` while editing content.

--- a/_posts/2026-01-26-maia-200-inference-infrastructure-lesson.md
+++ b/_posts/2026-01-26-maia-200-inference-infrastructure-lesson.md
@@ -9,9 +9,15 @@ status: [draft, series]
 
 Microsoft’s announcement of **MAIA 200**, a new AI accelerator designed specifically for inference, may feel far removed from rural broadband builds, electric co‑ops, or regional data center planning. But the story it tells is a familiar one to anyone who has spent time working on technology outside major metro markets.
 
-{% include callout.html type="info" title="What is inference?" content="Inference is the part of AI where the model actually does something for you. It’s the moment when an already‑trained model takes an input—your question, your photo, your document—and produces an output. If training is teaching the model how to think, inference is the model thinking in real time. A simple way to put it: Training = learning. Inference = using what was learned." %}
+{% include callout.html type="info" title="What is inference?" content="Inference is the part of AI where the model actually does something for you. It’s the moment when an already‑trained model takes an input—your question, your photo, your document—and produces an output. **If training is teaching the model how to think, inference is the model thinking in real time.** 
 
-See my post [The First 5 Things to Teach a Computer]({% post_url 2024-08-30-first-5-things-to-teach-computer %}).
+A simple way to put it: 
+
+**Training = learning**. 
+
+**Inference = using what was learned.**" %}
+
+> See my post [The First 5 Things to Teach a Computer]({% post_url  2024-08-30-first-5-things-to-teach-computer %}).
 
 In **smart buildings**, inference increasingly happens at the edge. HVAC controls, lighting, access, safety systems, and occupancy sensors need decisions in milliseconds and can’t rely on a round‑trip to the cloud. Edge inference keeps critical systems responsive during network outages, reduces bandwidth costs by processing high‑volume sensor streams locally, and improves privacy by keeping sensitive data on‑prem. It also enables real‑time energy optimization and predictive maintenance—turning buildings into adaptive systems rather than static infrastructure.
 
@@ -25,7 +31,7 @@ The same pattern played out with **cloud computing**. Early conversations focuse
 
 ---
 
-## Call‑Out: Why Internet Exchange Points Matter for AI Inference
+## Why Internet Exchange Points Matter for AI Inference
 
 As AI moves into everyday services—education platforms, healthcare tools, workforce systems—the **network path** becomes just as important as the compute running the model.
 
@@ -33,13 +39,13 @@ This is where **Internet Exchange Points (IXPs)** quietly become part of the AI 
 
 AI inference traffic is interactive, repetitive, and latency‑sensitive. Every prompt and response depends on fast, predictable back‑and‑forth communication between users and inference systems. IXPs improve this experience by allowing networks to interconnect directly and **keep traffic local longer**, instead of hauling it through distant metro hubs via paid transit.
 
-For rural and regional networks, IXPs:
+For rural, regional networks, IXPs:
 - Reduce latency and jitter for AI‑powered applications  
 - Lower transport and transit costs as inference traffic grows  
 - Improve resilience by enabling multiple local paths  
 - Support future regional AI caching and inference layers  
 
-{% include callout.html type="info" title="Connected Nation Internet Exchange Points (IXP.US)" content="Future Internet performance is at risk without a local IXP. As the Internet continues to evolve, reducing latency will be incredibly important. Autonomous vehicles, drones, artificial intelligence, video streaming, virtual reality, and precision agriculture will require ultra‑low‑latency connections—latency values that aren’t achievable in regions without an IXP. [1]" %}
+{% include callout.html type="info" title="According to Connected Nation Internet Exchange Points (IXP.US)" content="*Future Internet performance is at risk without a local IXP. As the Internet continues to evolve, reducing latency will be incredibly important. Autonomous vehicles, drones, artificial intelligence, video streaming, virtual reality, and precision agriculture will require ultra‑low‑latency connections—latency values that aren’t achievable in regions without an IXP.* [1]" %}
 
 Just as fiber made last‑mile broadband viable and cloud platforms reduced operational overhead, IXPs help AI behave less like a novelty service and more like **reliable infrastructure**. Communities with strong middle‑mile connectivity and accessible exchange points are better positioned to benefit from inference‑optimized platforms like MAIA 200—even when the AI compute itself lives in a distant Azure region.
 


### PR DESCRIPTION
Adds GitHub Actions workflow to build the site (installs Chromium for jekyll-diagrams), a Makefile for common commands, README notes, and fixes YAML and include parsing.